### PR TITLE
Allows Atom to manage font-size.

### DIFF
--- a/index.less
+++ b/index.less
@@ -16,7 +16,6 @@
   atom-text-editor, :host {
     line-height:1.3em;
     font-family: Menlo;
-    font-size: 12px;
   }
 }
 
@@ -25,7 +24,6 @@
   atom-text-editor, :host {
     line-height:1.3em;
     font-family: consolas;
-    font-size: 12px;
   }
 }
 


### PR DESCRIPTION
Does not automatically set editor font to 12px, and instead allows for Atom to dictate font size.

Before:
![before](https://cloud.githubusercontent.com/assets/2829082/15458001/9738ce06-2062-11e6-8ae6-8f802eb60721.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/2829082/15458002/992021ba-2062-11e6-8120-953a20bc529d.PNG)
